### PR TITLE
ci: Better packaging of executable for Linux and macOS

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -109,7 +109,10 @@ jobs:
           SEP=$(python -c "import os; print(os.pathsep)")
           pyinstaller --onefile -p src -n loveletter_cli src/loveletter_cli/__main__.py --add-data __version__.txt$SEP.
           ARTIFACT_PATH_ORIGINAL=$(find dist -type f -name "loveletter_cli*")
-          ARTIFACT_PATH=${ARTIFACT_NAME}.exe
+          ARTIFACT_PATH=$(echo $ARTIFACT_NAME | sed 's/\./_/g')  # escape dots as underscores
+          if [[ ${{ runner.os }} == 'Windows' ]]; then
+            ARTIFACT_PATH=$ARTIFACT_PATH.exe
+          fi
           mv $ARTIFACT_PATH_ORIGINAL $ARTIFACT_PATH
           echo "ARTIFACT_PATH=$ARTIFACT_PATH" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -124,7 +124,7 @@ jobs:
         shell: bash
 
       - name: Put executable in a tarball
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
         run: |
           TAR_PATH=$ARTIFACT_PATH.tar
           chmod +x $ARTIFACT_PATH

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -144,6 +144,8 @@ jobs:
         with:
           path: artifacts
 
+      - run: chmod +x $(find artifacts -type f)
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -120,6 +120,16 @@ jobs:
         run: ./$ARTIFACT_PATH --version
         shell: bash
 
+      - name: Put executable in a tarball
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          TAR_PATH=$ARTIFACT_PATH.tar
+          chmod +x $ARTIFACT_PATH
+          tar -cvf $TAR_PATH $ARTIFACT_PATH
+          ARTIFACT_PATH=$TAR_PATH
+          echo "ARTIFACT_PATH=$ARTIFACT_PATH" >> $GITHUB_ENV
+        shell: bash
+
       - name: Upload artifact to workflow
         uses: actions/upload-artifact@v3
         with:
@@ -143,8 +153,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: artifacts
-
-      - run: chmod +x $(find artifacts -type f)
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Puts the executable in a tarball so that the executable permission is preserved when the executable is unpacked.

Moreover, on macOS running the artifact just involves double clicking the tarball, which extracts the executable, and then double clicking the executable, which runs the program (GUI only, no terminal skills needed). Unfortunately it is not possible to require just a single double click, since file permissions are not maintained when downloading the bare executable from GitHub, so the user would have to `chmod +x` it in any case.

On Linux it still requires the user to launch the executable from the terminal, since there is no way of opening it in a terminal by double clicking. But extracting the TAR can be done wiht the GUI.

Closes #18 

- [x] Tested on Linux
- [ ] Tested on macOS