### PR TITLE
fix: Add timeout to connection attempt when joining server

### DIFF
--- a/src/loveletter_cli/session.py
+++ b/src/loveletter_cli/session.py
@@ -598,7 +598,7 @@ class GuestCLISession(CommandLineSession):
         while connection is None:
             try:
                 connection = await self.client.connect(*self.server_address)
-            except (ConnectionError, LogonError) as e:
+            except (OSError, LogonError) as e:
                 print("Error while trying to connect to the server:")
                 print_exception(e)
                 choice = await async_ask_valid_input(

--- a/src/loveletter_cli/session.py
+++ b/src/loveletter_cli/session.py
@@ -594,32 +594,36 @@ class GuestCLISession(CommandLineSession):
             RESTART = enum.auto()
             QUIT = enum.auto()
 
-        connection = None
-        while connection is None:
+        while True:
             try:
                 connection = await self.client.connect(*self.server_address)
+                break
+            except asyncio.exceptions.TimeoutError:
+                print("Connection attempt timed out.", end="\n\n")
             except (OSError, LogonError) as e:
                 print("Error while trying to connect to the server:")
                 print_exception(e)
-                choice = await async_ask_valid_input(
-                    "What would you like to do? ("
-                    "RETRY: retry connecting to this server; "
-                    "RESTART: restart Love Letter CLI (go back to username selection); "
-                    "QUIT: quit Love Letter CLI"
-                    ")",
-                    choices=ConnectionErrorOptions,
-                    default=ConnectionErrorOptions.RETRY,
-                )
-                if choice == ConnectionErrorOptions.RETRY:
-                    continue
-                elif choice == ConnectionErrorOptions.RESTART:
-                    raise Restart from None
-                elif choice == ConnectionErrorOptions.QUIT:
-                    sys.exit(1)
-                else:
-                    assert False
+
+            choice = await async_ask_valid_input(
+                "What would you like to do? ("
+                "RETRY: retry connecting to this server; "
+                "RESTART: restart Love Letter CLI (go back to username selection); "
+                "QUIT: quit Love Letter CLI"
+                ")",
+                choices=ConnectionErrorOptions,
+                default=ConnectionErrorOptions.RETRY,
+            )
+            if choice == ConnectionErrorOptions.RETRY:
+                continue
+            elif choice == ConnectionErrorOptions.RESTART:
+                raise Restart from None
+            elif choice == ConnectionErrorOptions.QUIT:
+                sys.exit(1)
+            else:
+                assert False
 
         print("Successfully connected to the server.")
+        # noinspection PyUnboundLocalVariable
         return connection
 
     async def _wait_for_game(self) -> RemoteGameShadowCopy:


### PR DESCRIPTION
This is to avoid waiting for a long time (the OS's default connection attempt timeout) when attempting to join a server on an unreachable address, e.g. due to a typo.

Closes #21