### PR TITLE
fix: Escape/avoid curly braces in valid8's help_msg

### DIFF
--- a/src/loveletter/cards.py
+++ b/src/loveletter/cards.py
@@ -323,7 +323,8 @@ class Countess(Card):
             "card",
             card_type,
             custom=lambda t: t not in disallowed,
-            help_msg=f"Can't play a {card_type.name.title()} with a Countess in hand",
+            help_msg="Can't play a {card_type} with a Countess in hand",
+            card_type=card_type.name.title(),
         )
 
 

--- a/src/loveletter/gameevent.py
+++ b/src/loveletter/gameevent.py
@@ -73,9 +73,11 @@ class GameInputRequest(GameEvent, metaclass=abc.ABCMeta):
             completed,
             custom=lambda o: o is self,
             help_msg=(
-                f"Did not receive the same GameInputRequest that was yielded: "
-                f"expected {self}, got {completed}"
+                "Did not receive the same GameInputRequest that was yielded: "
+                "expected {expected}, got {actual}"
             ),
+            expected=self,
+            actual=completed,
         )
         valid8.validate(
             "completed_step",

--- a/src/loveletter/gamenode.py
+++ b/src/loveletter/gamenode.py
@@ -45,8 +45,9 @@ class GameNode(metaclass=abc.ABCMeta):
     @valid8.validate_arg(
         "players",
         length_between(2, MAX_PLAYERS),
-        help_msg=f"Invalid number of players"
-        f" (should be at least 2 and at most {MAX_PLAYERS})",
+        help_msg="Invalid number of players"
+        " (should be at least 2 and at most {max_players})",
+        max_players=MAX_PLAYERS,
     )
     def __init__(self, players: Sequence[PlayerT]):
         """
@@ -95,9 +96,9 @@ class GameNode(metaclass=abc.ABCMeta):
             self.started,
             equals=False,
             help_msg=(
-                f"Can't start .play() once the {self.__class__.__name__} "
-                f"has already started"
+                "Can't start .play() once the {game_node_type} has already started"
             ),
+            game_node_type=self.__class__.__name__,
         )
 
         # noinspection PyArgumentList
@@ -136,7 +137,8 @@ class GameNode(metaclass=abc.ABCMeta):
             "started",
             self.started,
             equals=False,
-            help_msg=f"The {self.__class__.__name__} has already started",
+            help_msg="The {game_node_type} has already started",
+            game_node_type=self.__class__.__name__,
         )
 
     @abc.abstractmethod
@@ -150,13 +152,15 @@ class GameNode(metaclass=abc.ABCMeta):
             "started",
             self.started,
             equals=True,
-            help_msg=f"The {self.__class__.__name__} hasn't started yet",
+            help_msg="The {game_node_type} hasn't started yet",
+            game_node_type=self.__class__.__name__,
         )
         valid8.validate(
             "ended",
             self.ended,
             equals=False,
-            help_msg=f"The {self.__class__.__name__} has already ended",
+            help_msg="The {game_node_type} has already ended",
+            game_node_type=self.__class__.__name__,
         )
         self.state: IntermediateState
         intermediate_name = self.state.name
@@ -164,7 +168,8 @@ class GameNode(metaclass=abc.ABCMeta):
             intermediate_name,
             self.state,
             custom=lambda s: s.can_advance,
-            help_msg=f"Can't advance {intermediate_name} before previous one has ended",
+            help_msg="Can't advance {state_type} before previous one has ended",
+            state_type=intermediate_name,
         )
         return self.state
 

--- a/src/loveletter/round.py
+++ b/src/loveletter/round.py
@@ -195,7 +195,7 @@ class Round(GameNode):
             "player",
             player,
             is_in=self.players,
-            help_msg=f"Can't deal card to outside player",
+            help_msg="Can't deal card to outside player",
         )
         player.give(card := self.deck.take())
         return card
@@ -303,7 +303,8 @@ class Turn(RoundState, IntermediateState):
             "turn.stage",
             self.stage,
             equals=Turn.Stage.START,
-            help_msg=f"Can't start another move; turn is already {self.stage.name}",
+            help_msg="Can't start another move; turn is already {turn.stage.name}",
+            turn=self,
         )
         self._set_stage(Turn.Stage.IN_PROGRESS)
 

--- a/src/loveletter/roundplayer.py
+++ b/src/loveletter/roundplayer.py
@@ -129,7 +129,8 @@ class RoundPlayer:
             "turn",
             turn.current_player,
             custom=lambda p: p is self,
-            help_msg=f"It's not {self}'s turn",
+            help_msg="It's not {player}'s turn",
+            player=self,
         )
         valid8.validate(
             "card",

--- a/src/loveletter_cli/session.py
+++ b/src/loveletter_cli/session.py
@@ -261,8 +261,9 @@ class CommandLineSession(metaclass=abc.ABCMeta):
                     "nums",
                     set(nums),
                     equals=set(idx_range),
-                    help_msg=f"Each number in {list(idx_range)} should appear exactly "
-                    f"once, and nothing else.",
+                    help_msg="Each number in {numbers} should appear exactly"
+                    " once, and nothing else.",
+                    numbers=set(idx_range),
                 )
                 return nums
 

--- a/src/loveletter_cli/session.py
+++ b/src/loveletter_cli/session.py
@@ -261,7 +261,7 @@ class CommandLineSession(metaclass=abc.ABCMeta):
                     "nums",
                     set(nums),
                     equals=set(idx_range),
-                    help_msg=f"Each number in {set(idx_range)} should appear exactly "
+                    help_msg=f"Each number in {list(idx_range)} should appear exactly "
                     f"once, and nothing else.",
                 )
                 return nums


### PR DESCRIPTION
The help_msg is formatted by valid8 with the given context. So if a help_msg contains a bracket, it will be interpreted as a format field by valid8's internal .format() call. By only using valid8's help_msg formatting, avoiding f-strings, it is easier to (remember to) properly escape curly brackets.

This fix originates from a bug where writing invalid integers at the chancellor order prompt resulted in an unhandled help message formatting error due to curly braces in the set notation that were interpreted as format fields.